### PR TITLE
Proper initialization of $ret in getCode()

### DIFF
--- a/qrencode.php
+++ b/qrencode.php
@@ -129,7 +129,7 @@
         //----------------------------------------------------------------------
         public function getCode()
         {
-            $ret;
+            $ret = NULL;
 
             if($this->count < $this->dataLength) {
                 $row = $this->count % $this->blocks;


### PR DESCRIPTION
Current initialization causes "Undefined variable: ret" in HHVM
